### PR TITLE
Removed documentation_url in RoleMetaData

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,4 +19,3 @@ galaxy_info:
   categories:
   - system
 dependencies: []
-documentation_url: https://github.com/tcomerma/ansible-keepalived


### PR DESCRIPTION
`ansible --version                                                                                                                                                                                   
ansible 2.2.0.0
`
`ERROR! 'documentation_url' is not a valid attribute for a RoleMetadata`