### PR TITLE
fixed for ansible and script on keepalived

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,4 @@
+20171107:
+   - Fixes to check script, it was not working really: now MASTER and BACKUP works when you stop the process monitored (pablodav)
+   - Fix deprecated warning for service state=running - now state=started (pablodav)
+   - Fix wrong documentation type on mote in ansible 2.4 (pablodav)

--- a/README.md
+++ b/README.md
@@ -83,3 +83,8 @@ Apache
 Author Information
 ------------------
 Toni Comerma - tcomerma (at) gmail.com
+
+Collaborator Information
+------------------------
+
+Pablo Estigarribia - pablodav (at) gmail dot com

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,4 +19,3 @@ galaxy_info:
   categories:
   - system
 dependencies: []
-documentation_url: https://github.com/tcomerma/ansible-keepalived

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,11 +13,21 @@
   tags: keepalived
   notify: restart keepalived
 
+- name: chk_service script shell
+  template: 
+    src: check_script.sh.j2 
+    dest: /etc/keepalived/check_script.sh
+    mode: 0755
+    owner: root
+    group: root
+  tags: keepalived
+  notify: restart keepalived
+
 - name: Configurar configuració de keepalived
   template: src=keepalived.conf.j2 dest=/etc/keepalived/keepalived.conf
   tags: keepalived
   notify: restart keepalived
 
 - name: Start keepalived
-  service: name=keepalived state=running
+  service: name=keepalived state=started
   tags: keepalived

--- a/templates/check_script.sh.j2
+++ b/templates/check_script.sh.j2
@@ -1,0 +1,2 @@
+#!/bin/sh
+killall -0 {{ keepalived_check_process }}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -2,9 +2,8 @@
 global_defs {
 }
 vrrp_script chk_service {           # Requires keepalived-1.1.13
-        script "killall -0 {{ keepalived_check_process }}"     # cheaper than pidof
+        script '/etc/keepalived/check_script.sh'     # cheaper than pidof
         interval 2                      # check every 2 seconds
-        weight 2                        # add 2 points of prio if OK
 }
 vrrp_instance VI_1 {
     state {{ keepalived_role }}
@@ -23,7 +22,7 @@ vrrp_instance VI_1 {
     virtual_ipaddress {
         {{ keepalived_shared_ip }} dev {{ keepalived_shared_iface }} label {{ keepalived_shared_iface }}:0
     }
-        track_script {
-            chk_service
-        }
+    track_script {
+        chk_service
+    }
 }


### PR DESCRIPTION
fixes #5 
FULL CHANGELOG: 

20171107:
   - Fixes to check script, it was not working really: now MASTER and BACKUP works when you stop the process monitored (pablodav)
   - Fix deprecated warning for service state=running - now state=started (pablodav)
   - Fix wrong documentation type on mote in ansible 2.4 (pablodav)

The configuration was not really working, testing stopping a monitored process didn't change the float ip, but now it does works as expected.
